### PR TITLE
Update dependencies and fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 
-reqwest = { version = "0.11.4", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 url = { version = "2.1", features = ["serde"] }
 
-geo = { version = "0.27", features = ["use-serde"] }
+geo = { version = "0.29", features = ["use-serde"] }
 geojson = { version = "0.24", features = ["geo-types"] }
 rijksdriehoek = "0.1.0"
 

--- a/src/brk.rs
+++ b/src/brk.rs
@@ -116,7 +116,7 @@ impl BrkClient {
         );
 
         let u = url::Url::parse_with_params(
-            &format!("{}", BrkClient::BRK_URL),
+            BrkClient::BRK_URL,
             &[
                 ("request", "GetFeature"),
                 ("service", "WFS"),
@@ -126,33 +126,40 @@ impl BrkClient {
                 ("filter", &filter),
             ],
         )
-            .unwrap();
-        
+        .unwrap();
+
         let client_response = self
             .client
             .get(u.as_str())
             .send()
             .await
-            .map_err(|e| Error::NetworkProblem(e))?;
+            .map_err(Error::NetworkProblem)?;
 
-        let json: FeatureCollection = client_response.json().await.map_err(|e| Error::JsonProblem(e))?;
+        let json: FeatureCollection = client_response.json().await.map_err(Error::JsonProblem)?;
         let lots: Vec<Lot> = json
             .features
             .iter()
             .filter_map(|feature| {
                 Some(Lot {
-                    id: feature.property("identificatieLokaalID")?.as_str()?.to_string(),
+                    id: feature
+                        .property("identificatieLokaalID")?
+                        .as_str()?
+                        .to_string(),
                     gemeentenaam: Some(
-                        feature.property("kadastraleGemeenteWaarde")?.as_str()?.to_string()
+                        feature
+                            .property("kadastraleGemeenteWaarde")?
+                            .as_str()?
+                            .to_string(),
                     ),
                     kadastralegemeentecode: Some(
-                        feature.property("AKRKadastraleGemeenteCodeWaarde")?.as_str()?.to_string(),
+                        feature
+                            .property("AKRKadastraleGemeenteCodeWaarde")?
+                            .as_str()?
+                            .to_string(),
                     ),
                     grootte: feature.property("kadastraleGrootteWaarde")?.as_f64(),
                     sectie: Some(feature.property("sectie")?.as_str()?.to_string()),
-                    perceelnummer: Some(
-                        feature.property("perceelnummer")?.as_u64()?,
-                    ),
+                    perceelnummer: Some(feature.property("perceelnummer")?.as_u64()?),
                     geometry: feature.geometry.clone()?,
                 })
             })

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ pub fn bbox_wgs84_to_rijksdriehoek(bbox: Rect<f64>) -> Rect<f64> {
         Coord { x: rd.0, y: rd.1 }
     };
 
-    bbox.map_coords(&project_coord)
+    bbox.map_coords(project_coord)
 }
 
 /// Merge an iterator of bboxes to a single bbox.
@@ -40,9 +40,9 @@ pub fn polygon_to_bbox(value: geojson::Value) -> Result<Rect<f64>, ()> {
     shape.bounding_rect().ok_or(())
 }
 
-pub fn bbox_to_linestring(bbox: Rect<f64>) -> Result<geojson::Value, ()> {
-    let polygon: Polygon<f64> = bbox.try_into().or(Err(()))?;
-    Ok(geojson::Value::from(polygon.exterior()))
+pub fn bbox_to_linestring(bbox: Rect<f64>) -> geojson::Value {
+    let polygon: Polygon<f64> = bbox.into();
+    geojson::Value::from(polygon.exterior())
 }
 
 /// Return coordinate with easting (longitude) in x and northing (latitude) in y


### PR DESCRIPTION
One breaking change:
- `bbox_to_linestring` no longer returns a `Result`, as this is no longer needed with the newer version of `geo`